### PR TITLE
Update Configure-EnterpriseCA.ps1

### DIFF
--- a/Source/Hydration/Applications/Configure - Enterprise CA/Configure-EnterpriseCA.ps1
+++ b/Source/Hydration/Applications/Configure - Enterprise CA/Configure-EnterpriseCA.ps1
@@ -22,7 +22,14 @@ Start-Transcript $logFile
 Write-Host "Logging to $logFile" 
 
 # Configure Enterprise CA
-Install-AdcsCertificationAuthority `    –CAType EnterpriseRootCA `    –CACommonName "ViaMonstraRootCA" `    –KeyLength 2048 `    –HashAlgorithm SHA1 `    –CryptoProviderName "RSA#Microsoft Software Key Storage Provider" `    -ValidityPeriod Years `    -ValidityPeriodUnits 5 `
+Install-AdcsCertificationAuthority `
+    -CAType EnterpriseRootCA `
+    -CACommonName "ViaMonstraRootCA" `
+    -KeyLength 2048 `
+    -HashAlgorithm SHA1 `
+    -CryptoProviderName "RSA#Microsoft Software Key Storage Provider" `
+    -ValidityPeriod Years `
+    -ValidityPeriodUnits 5 `
     -Force
 
 # Stop logging 


### PR DESCRIPTION
Update Configure-EnterpriseCA.ps1
There are wrong characters in the first five parameters of the Install-AdcsCertificationAuthority cmdlet. Instead of the dash character we have a diamond with a question mark in VS Code and Notepad++. 
Also when I hit edit in GitHub to propose the changes, the following message appeared:  _We’ve detected the file encoding as windows-1252. When you commit changes we will transcode it to UTF-8._ 
The character displayed in GitHub's edit more is '–' instead '-'. I fixed it and proposing the change to be incorporated in this branch.

With regards