### PR TITLE
Update Configure-EnterpriseCA.ps1

### DIFF
--- a/Source/Hydration/Applications/Configure - Enterprise CA/Configure-EnterpriseCA.ps1
+++ b/Source/Hydration/Applications/Configure - Enterprise CA/Configure-EnterpriseCA.ps1
@@ -26,7 +26,7 @@ Install-AdcsCertificationAuthority `
     -CAType EnterpriseRootCA `
     -CACommonName "ViaMonstraRootCA" `
     -KeyLength 2048 `
-    -HashAlgorithm SHA1 `
+    -HashAlgorithm SHA256 `
     -CryptoProviderName "RSA#Microsoft Software Key Storage Provider" `
     -ValidityPeriod Years `
     -ValidityPeriodUnits 5 `


### PR DESCRIPTION
Hi, if we make use ADCS to replace self-signed certificate we'll be greeted by Firefox: "The certificate was signed using a signature algorithm that is disabled because it is not secure."

Purpose: Active Directory Certificate Services configuration change from SHA1 to SHA256 in Configure-EnterpriseCA.ps1

SHA256 would allow to the CA to deliver certificate using a signature algorithm more secure.

For the record i found an Advisory article dating 2015 describing the vulnerability of SHA-1 (160bit) and the Microsoft recommendation since then for best practice to use SHA-2.

https://learn.microsoft.com/en-us/security-updates/SecurityAdvisories/2015/3033929#advisory-faq

All possible Hashing Algorithms:
https://learn.microsoft.com/en-us/windows/win32/seccertenroll/cng-cryptographic-algorithm-providers#hashing-algorithms

Cheers